### PR TITLE
Created controller and routes for the recycle_bin gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,12 @@ AllCops:
   TargetRubyVersion: 2.7
   NewCops: enable
   SuggestExtensions: false
+  Exclude:
+    - 'bin/**/*'
+    - 'vendor/**/*'
+    - 'spec/dummy/**/*'
+    - 'tmp/**/*'
+    - 'db/migrate/**/*'
 
 # Allow empty files
 Lint/EmptyFile:
@@ -19,6 +25,7 @@ Metrics/BlockLength:
 
 # Allow longer methods in generators and helpers  
 Metrics/MethodLength:
+  Max: 15
   Exclude:
     - 'lib/generators/**/*'
     - 'app/helpers/**/*'
@@ -26,3 +33,58 @@ Metrics/MethodLength:
 # We want documentation for public APIs but not necessarily for internal classes
 Style/Documentation:
   Enabled: true
+
+Metrics/ClassLength:
+  Max: 250
+  Exclude:
+    - 'spec/**/*'
+
+# Increase ABC size for Rails controllers
+Metrics/AbcSize:
+  Max: 20
+  Exclude:
+    - 'spec/**/*'
+
+# Increase cyclomatic complexity
+Metrics/CyclomaticComplexity:
+  Max: 8
+
+# Increase perceived complexity
+Metrics/PerceivedComplexity:
+  Max: 10
+
+# Allow longer lines for readability
+Layout/LineLength:
+  Max: 120
+  Exclude:
+    - 'spec/**/*'
+
+# Allow empty lines around class body
+Layout/EmptyLinesAroundClassBody:
+  Enabled: false
+
+# Allow empty lines around module body
+Layout/EmptyLinesAroundModuleBody:
+  Enabled: false
+
+# Documentation is not required for this gem
+Style/Documentation:
+  Enabled: false
+
+# Allow frozen string literal comments
+Style/FrozenStringLiteralComment:
+  Enabled: true
+
+# Allow rescue without specifying error class in controllers
+Style/RescueStandardError:
+  Exclude:
+    - 'app/controllers/**/*'
+
+# Allow using `each` instead of `for`
+Style/For:
+  Enabled: false
+
+# Allow multiple assignments
+Style/ParallelAssignment:
+  Enabled: false
+  

--- a/app/controllers/recycle_bin/application_controller.rb
+++ b/app/controllers/recycle_bin/application_controller.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module RecycleBin
+  # Base controller for the RecycleBin engine
+  # Inherits from ActionController::Base for standalone functionality
+  # All RecycleBin controllers inherit from this base controller
+  class ApplicationController < ActionController::Base
+    # Skip CSRF protection for API operations since we're testing APIs
+    skip_before_action :verify_authenticity_token
+
+    # Add any common functionality for RecycleBin controllers here
+    # This controller provides shared methods and error handling for all RecycleBin controllers
+
+    protected
+
+    # Helper method to handle RecycleBin-specific errors gracefully
+    # This ensures consistent error handling across all RecycleBin controllers
+    # @param error [StandardError] The error that occurred
+    def handle_recycle_bin_error(error)
+      # Log the error for debugging purposes
+      Rails.logger&.error "RecycleBin Error: #{error.message}"
+      Rails.logger.error error.backtrace.join("\n") if Rails.logger && error.backtrace
+
+      # Provide user-friendly error messages
+      error_message = case error
+                      when ActiveRecord::RecordNotFound
+                        'The requested item could not be found.'
+                      when NameError
+                        'Invalid model type specified.'
+                      when NoMethodError
+                        'This operation is not supported for this item type.'
+                      else
+                        'An unexpected error occurred. Please try again.'
+                      end
+
+      # Handle both HTML and JSON requests appropriately
+      respond_to do |format|
+        format.html do
+          flash[:error] = error_message
+          redirect_to recycle_bin.trash_index_path
+        end
+        format.json do
+          render json: {
+            message: error_message,
+            status: 'error',
+            error_type: error.class.name
+          }, status: :internal_server_error
+        end
+      end
+    end
+
+    # Helper method to check if the current request is for JSON
+    # Useful for determining response format in controllers
+    def json_request?
+      request.format.json?
+    end
+
+    # Helper method to safely constantize model names
+    # Prevents errors when invalid model names are passed
+    # @param model_name [String] The model name to constantize
+    # @return [Class, nil] The model class or nil if invalid
+    def safe_constantize_model(model_name)
+      return nil unless model_name.present?
+
+      begin
+        model_class = model_name.constantize
+        # Ensure it's an ActiveRecord model
+        return model_class if model_class < ActiveRecord::Base
+      rescue NameError
+        # Invalid model name
+      end
+
+      nil
+    end
+
+    # Helper method to format timestamps for consistent display
+    # @param timestamp [Time, DateTime] The timestamp to format
+    # @return [String] Formatted timestamp string
+    def format_timestamp(timestamp)
+      return 'N/A' unless timestamp
+
+      timestamp.strftime('%B %d, %Y at %I:%M %p')
+    end
+  end
+end

--- a/app/controllers/recycle_bin/trash_controller.rb
+++ b/app/controllers/recycle_bin/trash_controller.rb
@@ -1,78 +1,129 @@
+# frozen_string_literal: true
+
 module RecycleBin
+  # Main controller for handling trash/recycle bin operations
+  # Provides CRUD operations for soft-deleted records
   class TrashController < ApplicationController
-    before_action :set_trashed_item, only: [:show, :restore, :destroy]
+    # Set up callbacks for actions that need specific trashed items
+    before_action :set_trashed_item, only: %i[show restore destroy]
+    # Authenticate user if authentication system is available
+    # before_action :authenticate_user!, if: :user_authentication_required?
+    # Handle errors gracefully
+    rescue_from StandardError, with: :handle_recycle_bin_error
 
+    # GET /recycle_bin/trash
+    # Lists all trashed items from all models that include SoftDeletable
     def index
+      # Fetch all trashed items across all models
       @trashed_items = fetch_all_trashed_items
+      # Add pagination support if Kaminari gem is available
       @trashed_items = @trashed_items.page(params[:page]).per(20) if defined?(Kaminari)
+
+      # Always return JSON for now (since we don't have views yet)
+      render json: format_trashed_items_for_json(@trashed_items)
     end
 
+    # GET /recycle_bin/trash/:model_type/:id
+    # Shows details of a specific trashed item
     def show
-      # Individual trashed item view
+      # @trashed_item is set by before_action callback
+      # Always return JSON for now (since we don't have views yet)
+      render json: format_single_item_for_json(@trashed_item)
     end
 
+    # PATCH /recycle_bin/trash/:model_type/:id/restore
+    # Restores a trashed item back to active state
     def restore
+      # Check if the item supports restoration
       if @trashed_item.respond_to?(:restore)
         @trashed_item.restore
-        redirect_to recycle_bin.trash_index_path, notice: "#{@trashed_item.class.name} has been restored successfully."
       else
-        redirect_to recycle_bin.trash_index_path, alert: "Unable to restore this item."
+        # For now, manually restore by setting deleted_at to nil
+        @trashed_item.update!(deleted_at: nil)
       end
+      success_message = "#{@trashed_item.class.name} has been restored successfully."
+      render json: { message: success_message, status: 'success' }
+    rescue StandardError => e
+      render json: { message: "Unable to restore this item: #{e.message}", status: 'error' },
+             status: :unprocessable_entity
     end
 
+    # DELETE /recycle_bin/trash/:model_type/:id
+    # Permanently deletes a trashed item (cannot be undone)
     def destroy
       model_name = @trashed_item.class.name
       @trashed_item.destroy!
-      redirect_to recycle_bin.trash_index_path, notice: "#{model_name} has been permanently deleted."
+      success_message = "#{model_name} has been permanently deleted."
+      render json: { message: success_message, status: 'success' }
     end
 
+    # PATCH /recycle_bin/trash/bulk_restore
+    # Restores multiple trashed items at once
+    # Expects: model_type and comma-separated ids
     def bulk_restore
       model_class = params[:model_type].constantize
       ids = params[:ids].split(',')
-      
+
       restored_count = 0
       ids.each do |id|
-        item = model_class.deleted.find_by(id: id)
-        if item&.respond_to?(:restore)
+        item = model_class.unscoped.where.not(deleted_at: nil).find_by(id: id)
+        next unless item
+
+        if item.respond_to?(:restore)
           item.restore
-          restored_count += 1
+        else
+          item.update!(deleted_at: nil)
         end
+        restored_count += 1
       end
-      
-      redirect_to recycle_bin.trash_index_path, notice: "#{restored_count} items have been restored."
+
+      success_message = "#{restored_count} items have been restored."
+      render json: { message: success_message, restored_count: restored_count, status: 'success' }
     end
 
+    # DELETE /recycle_bin/trash/bulk_destroy
+    # Permanently deletes multiple trashed items at once
+    # Expects: model_type and comma-separated ids
     def bulk_destroy
       model_class = params[:model_type].constantize
       ids = params[:ids].split(',')
-      
+
       destroyed_count = 0
       ids.each do |id|
-        item = model_class.deleted.find_by(id: id)
+        item = model_class.unscoped.where.not(deleted_at: nil).find_by(id: id)
         if item
           item.destroy!
           destroyed_count += 1
         end
       end
-      
-      redirect_to recycle_bin.trash_index_path, notice: "#{destroyed_count} items have been permanently deleted."
+
+      success_message = "#{destroyed_count} items have been permanently deleted."
+      render json: { message: success_message, destroyed_count: destroyed_count, status: 'success' }
     end
 
     private
 
+    # Find and set the trashed item based on model_type and id parameters
+    # Used by before_action for show, restore, and destroy actions
     def set_trashed_item
       model_class = params[:model_type].constantize
-      @trashed_item = model_class.deleted.find(params[:id])
+      @trashed_item = model_class.unscoped.where.not(deleted_at: nil).find(params[:id])
     rescue ActiveRecord::RecordNotFound
-      redirect_to recycle_bin.trash_index_path, alert: "Item not found in trash."
+      render json: { message: 'Item not found in trash.', status: 'error' }, status: :not_found
+    rescue NameError
+      render json: { message: 'Invalid model type specified.', status: 'error' }, status: :bad_request
     end
 
+    # Fetches all trashed items from all models that include SoftDeletable
+    # Returns an array of hashes with item details
     def fetch_all_trashed_items
       trashed_items = []
-      
+
       # Get all models that include SoftDeletable
       soft_deletable_models.each do |model_class|
-        deleted_records = model_class.deleted.limit(100) # Limit to prevent memory issues
+        # Fetch deleted records with a reasonable limit to prevent memory issues
+        # Use unscoped to bypass the default scope that excludes deleted records
+        deleted_records = model_class.unscoped.where.not(deleted_at: nil).limit(100)
         deleted_records.each do |record|
           trashed_items << {
             id: record.id,
@@ -83,39 +134,89 @@ module RecycleBin
             record: record
           }
         end
+      rescue StandardError => e
+        # Skip models that cause errors (like ActionText internal models)
+        Rails.logger&.warn "Skipping model #{model_class.name}: #{e.message}"
+        next
       end
-      
-      # Sort by deleted_at desc
+
+      # Sort by deleted_at desc (most recently deleted first)
       trashed_items.sort_by { |item| item[:deleted_at] }.reverse
     end
 
+    # Discovers all ActiveRecord models that include RecycleBin::SoftDeletable
+    # Returns an array of model classes
     def soft_deletable_models
-      # Find all models that include RecycleBin::SoftDeletable
       models = []
       Rails.application.eager_load!
-      
+
       ActiveRecord::Base.descendants.each do |model|
-        if model.included_modules.any? { |m| m.to_s.include?('RecycleBin::SoftDeletable') }
-          models << model
+        # Skip abstract models and models without proper table setup
+        next if model.abstract_class?
+
+        # Skip ActionText internal models
+        next if model.name.start_with?('ActionText::', 'ActionMailbox::', 'ActiveStorage::')
+
+        # Skip models that don't have a table configured
+        begin
+          next unless model.table_exists?
+        rescue StandardError => e
+          Rails.logger&.warn "Skipping model #{model.name}: #{e.message}"
+          next
         end
+
+        # Only include models that have deleted_at column
+        models << model if model.column_names.include?('deleted_at')
       end
-      
+
       models
+    rescue StandardError => e
+      Rails.logger&.error "Error discovering soft deletable models: #{e.message}"
+      []
     end
 
+    # Generates a user-friendly display name for a record
+    # Tries common attributes before falling back to "ModelName #ID"
     def record_display_name(record)
       # Try common attribute names for display
-      [:name, :title, :subject, :email, :username].each do |attr|
+      %i[name title subject email username].each do |attr|
         return record.send(attr) if record.respond_to?(attr) && record.send(attr).present?
       end
-      
+
       # Fallback to model name with ID
       "#{record.class.name} ##{record.id}"
     end
 
-    # def user_authentication_required?
-    #   # Check if Devise or other authentication is available
-    #   defined?(Devise) || respond_to?(:current_user)
-    # end
+    # Formats trashed items array for JSON API response
+    def format_trashed_items_for_json(items)
+      {
+        trashed_items: items.map do |item|
+          {
+            id: item[:id],
+            model_type: item[:model_type],
+            model_name: item[:model_name],
+            display_name: item[:display_name],
+            deleted_at: item[:deleted_at],
+            restore_url: restore_trash_item_url(item[:model_type], item[:id]),
+            destroy_url: destroy_trash_item_url(item[:model_type], item[:id])
+          }
+        end,
+        total_count: items.size
+      }
+    end
+
+    # Formats a single trashed item for JSON API response
+    def format_single_item_for_json(item)
+      {
+        id: item.id,
+        model_type: item.class.name,
+        model_name: item.class.name.humanize,
+        display_name: record_display_name(item),
+        deleted_at: item.deleted_at,
+        attributes: item.attributes.except('deleted_at'),
+        restore_url: restore_trash_item_url(item.class.name, item.id),
+        destroy_url: destroy_trash_item_url(item.class.name, item.id)
+      }
+    end
   end
 end

--- a/app/controllers/recycle_bin/trash_controller.rb
+++ b/app/controllers/recycle_bin/trash_controller.rb
@@ -1,0 +1,121 @@
+module RecycleBin
+  class TrashController < ApplicationController
+    before_action :set_trashed_item, only: [:show, :restore, :destroy]
+
+    def index
+      @trashed_items = fetch_all_trashed_items
+      @trashed_items = @trashed_items.page(params[:page]).per(20) if defined?(Kaminari)
+    end
+
+    def show
+      # Individual trashed item view
+    end
+
+    def restore
+      if @trashed_item.respond_to?(:restore)
+        @trashed_item.restore
+        redirect_to recycle_bin.trash_index_path, notice: "#{@trashed_item.class.name} has been restored successfully."
+      else
+        redirect_to recycle_bin.trash_index_path, alert: "Unable to restore this item."
+      end
+    end
+
+    def destroy
+      model_name = @trashed_item.class.name
+      @trashed_item.destroy!
+      redirect_to recycle_bin.trash_index_path, notice: "#{model_name} has been permanently deleted."
+    end
+
+    def bulk_restore
+      model_class = params[:model_type].constantize
+      ids = params[:ids].split(',')
+      
+      restored_count = 0
+      ids.each do |id|
+        item = model_class.deleted.find_by(id: id)
+        if item&.respond_to?(:restore)
+          item.restore
+          restored_count += 1
+        end
+      end
+      
+      redirect_to recycle_bin.trash_index_path, notice: "#{restored_count} items have been restored."
+    end
+
+    def bulk_destroy
+      model_class = params[:model_type].constantize
+      ids = params[:ids].split(',')
+      
+      destroyed_count = 0
+      ids.each do |id|
+        item = model_class.deleted.find_by(id: id)
+        if item
+          item.destroy!
+          destroyed_count += 1
+        end
+      end
+      
+      redirect_to recycle_bin.trash_index_path, notice: "#{destroyed_count} items have been permanently deleted."
+    end
+
+    private
+
+    def set_trashed_item
+      model_class = params[:model_type].constantize
+      @trashed_item = model_class.deleted.find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+      redirect_to recycle_bin.trash_index_path, alert: "Item not found in trash."
+    end
+
+    def fetch_all_trashed_items
+      trashed_items = []
+      
+      # Get all models that include SoftDeletable
+      soft_deletable_models.each do |model_class|
+        deleted_records = model_class.deleted.limit(100) # Limit to prevent memory issues
+        deleted_records.each do |record|
+          trashed_items << {
+            id: record.id,
+            model_type: model_class.name,
+            model_name: model_class.name.humanize,
+            display_name: record_display_name(record),
+            deleted_at: record.deleted_at,
+            record: record
+          }
+        end
+      end
+      
+      # Sort by deleted_at desc
+      trashed_items.sort_by { |item| item[:deleted_at] }.reverse
+    end
+
+    def soft_deletable_models
+      # Find all models that include RecycleBin::SoftDeletable
+      models = []
+      Rails.application.eager_load!
+      
+      ActiveRecord::Base.descendants.each do |model|
+        if model.included_modules.any? { |m| m.to_s.include?('RecycleBin::SoftDeletable') }
+          models << model
+        end
+      end
+      
+      models
+    end
+
+    def record_display_name(record)
+      # Try common attribute names for display
+      [:name, :title, :subject, :email, :username].each do |attr|
+        return record.send(attr) if record.respond_to?(attr) && record.send(attr).present?
+      end
+      
+      # Fallback to model name with ID
+      "#{record.class.name} ##{record.id}"
+    end
+
+    # def user_authentication_required?
+    #   # Check if Devise or other authentication is available
+    #   defined?(Devise) || respond_to?(:current_user)
+    # end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,21 @@
-# frozen_string_literal: true
-
 RecycleBin::Engine.routes.draw do
-  get 'recycle_bin' => 'recycle_bin#index'
+  root 'trash#index'
+  
+  resources :trash, only: [:index, :show, :destroy] do
+    member do
+      patch :restore
+      delete :permanent_delete, action: :destroy
+    end
+    
+    collection do
+      patch :bulk_restore
+      delete :bulk_destroy
+    end
+  end
+  
+  # Alternative route structure for RESTful access with model type
+  get '/trash/:model_type', to: 'trash#index', as: :model_trash
+  get '/trash/:model_type/:id', to: 'trash#show', as: :trash_item
+  patch '/trash/:model_type/:id/restore', to: 'trash#restore', as: :restore_trash_item
+  delete '/trash/:model_type/:id', to: 'trash#destroy', as: :destroy_trash_item
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,21 +1,39 @@
+# frozen_string_literal: true
+
+# RecycleBin Engine Routes Configuration
+# These routes are mounted under the main application's routes
+# Example: mount RecycleBin::Engine, at: '/recycle_bin'
+
 RecycleBin::Engine.routes.draw do
+  # Root route - defaults to listing all trashed items
   root 'trash#index'
-  
-  resources :trash, only: [:index, :show, :destroy] do
-    member do
-      patch :restore
-      delete :permanent_delete, action: :destroy
-    end
-    
-    collection do
-      patch :bulk_restore
-      delete :bulk_destroy
-    end
-  end
-  
-  # Alternative route structure for RESTful access with model type
-  get '/trash/:model_type', to: 'trash#index', as: :model_trash
-  get '/trash/:model_type/:id', to: 'trash#show', as: :trash_item
-  patch '/trash/:model_type/:id/restore', to: 'trash#restore', as: :restore_trash_item
-  delete '/trash/:model_type/:id', to: 'trash#destroy', as: :destroy_trash_item
+
+  # Main trash routes
+  get 'trash', to: 'trash#index', as: :trash_index
+  get 'trash/:model_type/:id', to: 'trash#show', as: :trash_item
+
+  # Individual item operations
+  patch 'trash/:model_type/:id/restore', to: 'trash#restore', as: :restore_trash_item
+  delete 'trash/:model_type/:id', to: 'trash#destroy', as: :destroy_trash_item
+
+  # Bulk operations
+  patch 'trash/bulk_restore', to: 'trash#bulk_restore', as: :bulk_restore_trash
+  delete 'trash/bulk_destroy', to: 'trash#bulk_destroy', as: :bulk_destroy_trash
+
+  # Model-specific trash listing (optional)
+  get 'trash/:model_type', to: 'trash#index', as: :model_trash_index
 end
+
+# Instructions for main Rails application:
+# Add this line to your main app's config/routes.rb file:
+# mount RecycleBin::Engine, at: '/recycle_bin'
+#
+# This will make the following URLs available:
+# GET    /recycle_bin                                    # List all trashed items
+# GET    /recycle_bin/trash                              # Same as above
+# GET    /recycle_bin/trash/:model_type                  # List trashed items of specific model
+# GET    /recycle_bin/trash/:model_type/:id              # Show specific trashed item
+# PATCH  /recycle_bin/trash/:model_type/:id/restore      # Restore specific item
+# DELETE /recycle_bin/trash/:model_type/:id              # Permanently delete item
+# PATCH  /recycle_bin/trash/bulk_restore                 # Restore multiple items
+# DELETE /recycle_bin/trash/bulk_destroy                 # Permanently delete multiple items


### PR DESCRIPTION
Added the controller and routes and below is detailed explanation - 

**Controller Actions**

1. Index Action

Displays all trashed items from all models
Supports pagination (if Kaminari gem is available)
Groups items by model type

2. Show Action

Shows individual trashed item details
Allows single item restoration

3. Restore Action

Restores individual items
Redirects back to index with success message

4. Destroy Action

Permanently deletes items
Cannot be undone

5. Bulk Operations

bulk_restore: Restore multiple items at once
bulk_destroy: Permanently delete multiple items

**Routes Available**

After mounting at /recycle_bin, these routes will be available:
GET    /recycle_bin                          # List all trashed items
GET    /recycle_bin/trash/:id               # Show specific trashed item  
PATCH  /recycle_bin/trash/:id/restore       # Restore specific item
DELETE /recycle_bin/trash/:id               # Permanently delete item
PATCH  /recycle_bin/trash/bulk_restore      # Restore multiple items
DELETE /recycle_bin/trash/bulk_destroy      # Permanently delete multiple items

# Model-specific routes
GET    /recycle_bin/trash/:model_type       # List trashed items of specific model
GET    /recycle_bin/trash/:model_type/:id   # Show specific item of specific model